### PR TITLE
rewrite uris platform independent

### DIFF
--- a/remote_fs_test.go
+++ b/remote_fs_test.go
@@ -8,9 +8,11 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -59,26 +61,26 @@ func TestClone(t *testing.T) {
 
 		discoveredFiles := make(map[string]string)
 
-		err = filepath.Walk(baseDir, func(path string, info os.FileInfo, err error) error {
+		err = filepath.Walk(baseDir, func(currPath string, info os.FileInfo, err error) error {
 
 			if err != nil {
-				return errors.Wrapf(err, "when walking walkFunc for path %s", path)
+				return errors.Wrapf(err, "when walking walkFunc for path %s", currPath)
 			}
 
 			if info.IsDir() {
 				return nil
 			}
 
-			content, err := ioutil.ReadFile(path)
+			content, err := ioutil.ReadFile(currPath)
 			if err != nil {
-				return errors.Wrapf(err, "when calling readFile for path %s", path)
+				return errors.Wrapf(err, "when calling readFile for path %s", currPath)
 			}
 
-			if pathHasPrefix(path, baseDir) {
-				path = filepath.Join("/", pathTrimPrefix(path, baseDir))
+			if filepathHasPrefix(currPath, baseDir) {
+				currPath = path.Join("/", filepath.ToSlash(filepathTrimPrefix(currPath, baseDir)))
 			}
 
-			discoveredFiles[path] = string(content)
+			discoveredFiles[currPath] = string(content)
 
 			return nil
 		})
@@ -401,3 +403,11 @@ func (client *testFS) Handle(ctx context.Context, conn *jsonrpc2.Conn, req *json
 type noopHandler struct{}
 
 func (noopHandler) Handle(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) {}
+
+func pathHasPrefix(s, prefix string) bool {
+	var prefixSlash string
+	if prefix != "" && !strings.HasSuffix(prefix, "/") {
+		prefixSlash = prefix + "/"
+	}
+	return s == prefix || strings.HasPrefix(s, prefixSlash)
+}

--- a/uris.go
+++ b/uris.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -48,7 +49,7 @@ func clientToServerURI(uri lsp.DocumentURI, cacheDir string) lsp.DocumentURI {
 
 	// We assume that any path provided by the client to the server
 	// is a project path that is relative to '/'
-	parsedURI.Path = filepath.Join(cacheDir, parsedURI.Path)
+	parsedURI.Path = filepath.Join(cacheDir, filepath.FromSlash(parsedURI.Path))
 	return lsp.DocumentURI(parsedURI.String())
 }
 
@@ -67,8 +68,8 @@ func serverToClientURI(uri lsp.DocumentURI, cacheDir string) lsp.DocumentURI {
 	// Only rewrite uris that point to a location in the workspace cache. If it does
 	// point to a cache location, then we assume that the path points to a location in the
 	// project.
-	if pathHasPrefix(parsedURI.Path, cacheDir) {
-		parsedURI.Path = filepath.Join("/", pathTrimPrefix(parsedURI.Path, cacheDir))
+	if filepathHasPrefix(parsedURI.Path, cacheDir) {
+		parsedURI.Path = path.Join("/", filepath.ToSlash(filepathTrimPrefix(parsedURI.Path, cacheDir)))
 	}
 
 	return lsp.DocumentURI(parsedURI.String())
@@ -87,7 +88,7 @@ func probablyFileURI(candidate *url.URL) bool {
 }
 
 // copied from sourcegraph/go-langserver/util.go
-func pathHasPrefix(s, prefix string) bool {
+func filepathHasPrefix(s, prefix string) bool {
 	var prefixSlash string
 	if prefix != "" && !strings.HasSuffix(prefix, string(os.PathSeparator)) {
 		prefixSlash = prefix + string(os.PathSeparator)
@@ -96,7 +97,7 @@ func pathHasPrefix(s, prefix string) bool {
 }
 
 // copied from sourcegraph/go-langserver/util.go
-func pathTrimPrefix(s, prefix string) string {
+func filepathTrimPrefix(s, prefix string) string {
 	if s == prefix {
 		return ""
 	}


### PR DESCRIPTION
- Rename `pathHasPrefix -> filepathHasPrefix`, `pathTrimPrefix -> filepathTrimPrefix` to following `path` and `filepath` convention in stdlib (these function use `os.PathSep`). 

- use `filepath.[To/From]Slash` as appropriate in the uri re-writing functions 

- update tests to use platform independent paths