### PR TITLE
JSONRPC2 ID rewrite flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,15 @@ Usage: lsp-adapter [OPTIONS] LSP_COMMAND_ARGS...
 
 Options:
   -cacheDirectory string
-    	cache directory location (default "/var/folders/qq/1q_cmsmx6qv7bs_m6g_2pt1r0000gn/T/proxy-cache")
+      cache directory location (default "/tmp/proxy-cache")
   -didOpenLanguage string
-    	(HACK) If non-empty, send 'textDocument/didOpen' notifications with the specified language field (e.x. 'python') to the language server for every file.
+      (HACK) If non-empty, send 'textDocument/didOpen' notifications with the specified language field (e.x. 'python') to the language server for every file.
+  -jsonrpc2IDRewrite string
+      (HACK) Rewrite jsonrpc2 ID. none (default) is no rewriting. string will use a string ID. number will use a number ID. Useful for language servers with non-spec complaint JSONRPC2 implementations. (default "none")
   -proxyAddress string
-    	proxy server listen address (tcp) (default "127.0.0.1:8080")
+      proxy server listen address (tcp) (default "127.0.0.1:8080")
   -trace
-    	trace logs to stderr
+      trace logs to stderr
 ```
 ## How to Use `lsp-adapter`
 
@@ -101,4 +103,9 @@ There is a [skeleton Dockerfile](./Dockerfile) that shows how to package `lsp-ad
 
 ## Did Open Hack 
 
-Some language servers incorrectly follow the LSP spec, and refuse to work unless the `textDocument/didOpen` notification has been sent. See [this commit](https://github.com/sourcegraph/lsp-adapter/commit/1228a1fbaf102aa44575cec6802a5a211d117ee1) for more context. If the language server that you’re trying to use has this issue, try setting the `didOpenLanguage` flag (example: if a python language server had this issue - use `./lsp-adapter -didOpenLanguage=’python’...`) to work around it. 
+Some language servers incorrectly follow the LSP spec, and refuse to work unless the `textDocument/didOpen` notification has been sent. See [this commit](https://github.com/sourcegraph/lsp-adapter/commit/1228a1fbaf102aa44575cec6802a5a211d117ee1) for more context. If the language server that you’re trying to use has this issue, try setting the `didOpenLanguage` flag (example: if a python language server had this issue - use `./lsp-adapter -didOpenLanguage=python ...`) to work around it.
+
+
+## JSONRPC2 ID Rewrite Hack
+
+Some langauge servers incorrectly follow the JSONRPC2 spec, and fail if the Request ID is not a number of string. If the language server that you’re trying to use has this issue, try setting the `jsonrpc2IDRewrite` flag (example: if a rust language server had this issue - use `./lsp-adapter -jsonrpc2IDRewrite=number ...`) to work around it.

--- a/dockerfiles/clojure/Dockerfile
+++ b/dockerfiles/clojure/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:1.10-alpine
+WORKDIR /go/src/github.com/sourcegraph/lsp-adapter
+COPY . .
+RUN CGO_ENABLED=0 GOBIN=/usr/local/bin go install github.com/sourcegraph/lsp-adapter
+
+FROM clojure:lein-2.8.1-alpine
+RUN apk add --no-cache ca-certificates git
+RUN git clone https://github.com/snoe/clojure-lsp.git
+WORKDIR clojure-lsp
+RUN lein deps
+RUN lein compile
+
+COPY --from=0 /usr/local/bin/lsp-adapter /usr/local/bin/
+EXPOSE 8080
+# clojure-lsp does not support int ID fields https://github.com/snoe/clojure-lsp/issues/4
+CMD ["lsp-adapter", "-proxyAddress=0.0.0.0:8080", "-jsonrpc2IDRewrite=string", "lein", "run"]

--- a/dockerfiles/rust/Dockerfile
+++ b/dockerfiles/rust/Dockerfile
@@ -9,4 +9,5 @@ RUN rustup component add rls-preview rust-analysis rust-src
 
 COPY --from=0 /usr/local/bin/lsp-adapter /usr/local/bin/
 EXPOSE 8080
-CMD ["lsp-adapter", "--proxyAddress=0.0.0.0:8080", "rls"]
+# RLS does not support string ID fields https://github.com/rust-lang-nursery/rls/issues/805
+CMD ["lsp-adapter", "-proxyAddress=0.0.0.0:8080", "-jsonrpc2IDRewrite=number", "rls"]


### PR DESCRIPTION
Allow us to switch between no rewriting, a number or string for the ID we send to language servers. Ideally we should always just do no rewriting, but unfortunately there examples of LS only supporting numbers (rust) or strings (clojure)