### PR TITLE
swift: script to run on macOS

### DIFF
--- a/dockerfiles/swift/.gitignore
+++ b/dockerfiles/swift/.gitignore
@@ -1,0 +1,1 @@
+langserver-swift

--- a/dockerfiles/swift/run.sh
+++ b/dockerfiles/swift/run.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# until we have linux support, this script automates building and running on macOS
+# https://github.com/RLovelett/langserver-swift/issues/18
+
+set -eax
+
+if [ ! -d langserver-swift ]; then
+    git clone https://github.com/RLovelett/langserver-swift.git
+fi
+
+COMMIT=838d8fadfc9fad82c8c1417e2f70a7d73f6347ee
+cd langserver-swift
+git checkout $COMMIT || (git fetch && git checkout $COMMIT)
+make debug
+
+lsp-adapter -trace -didOpenLanguage=swift .build/x86_64-apple-macosx10.10/debug/langserver-swift


### PR DESCRIPTION
Swift language server works a bit better since https://github.com/RLovelett/langserver-swift/commit/838d8fadfc9fad82c8c1417e2f70a7d73f6347ee

Still no linux support, so for now including a simple script to make testing in future easier.

I pretty much never get a hover working, except for some builtin types (like Int32). Maybe it depends on some build steps running?