### PR TITLE
add dockerfile for html language server

### DIFF
--- a/dockerfiles/html/Dockerfile
+++ b/dockerfiles/html/Dockerfile
@@ -18,7 +18,7 @@ USER node
 # see https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md#global-npm-dependencies
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 ENV PATH=$PATH:/home/node/.npm-global/bin
-RUN npm i -g vscode-html-languageserver-bin
+RUN npm i -g vscode-html-languageserver-bin@1
 
 COPY --from=0 /usr/local/bin/lsp-adapter /usr/local/bin
 EXPOSE 8080

--- a/dockerfiles/html/Dockerfile
+++ b/dockerfiles/html/Dockerfile
@@ -1,0 +1,26 @@
+FROM golang:1.10-alpine
+WORKDIR /go/src/github.com/sourcegraph/lsp-adapter
+COPY . .
+RUN CGO_ENABLED=0 GOBIN=/usr/local/bin go install github.com/sourcegraph/lsp-adapter
+
+# 👀 Add steps here to build the language server itself 👀
+# CMD ["echo", "🚨 This statement should be removed once you have added the logic to start up the language server! 🚨 Exiting..."]
+
+FROM node:9
+
+# Use tini as entrypoint to correctly handle signals and zombie processes.
+ENV TINI_VERSION v0.18.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+ENTRYPOINT ["/tini", "--"]
+
+USER node
+# see https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md#global-npm-dependencies
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+ENV PATH=$PATH:/home/node/.npm-global/bin
+RUN npm i -g vscode-html-languageserver-bin
+
+COPY --from=0 /usr/local/bin/lsp-adapter /usr/local/bin
+EXPOSE 8080
+# Modify this command to connect to the language server
+CMD ["lsp-adapter", "--trace", "--didOpenLanguage='html'", "--proxyAddress=0.0.0.0:8080", "html-languageserver", "--stdio"]


### PR DESCRIPTION

![screen recording 2018-04-27 at 11 19 am](https://user-images.githubusercontent.com/9022011/39378645-dde2d668-4a0d-11e8-8e9b-e15e599f6ea9.gif)
LS: https://github.com/vscode-langservers/vscode-html-languageserver-bin

Note that this language server needs the `didOpen` hack

cc @keegancsmith 