### PR TITLE
add dockerfile for css lang server

### DIFF
--- a/dockerfiles/css/Dockerfile
+++ b/dockerfiles/css/Dockerfile
@@ -18,7 +18,7 @@ USER node
 # see https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md#global-npm-dependencies
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 ENV PATH=$PATH:/home/node/.npm-global/bin
-RUN npm i -g vscode-css-languageserver-bin
+RUN npm i -g vscode-css-languageserver-bin@1
 
 COPY --from=0 /usr/local/bin/lsp-adapter /usr/local/bin
 EXPOSE 8080

--- a/dockerfiles/css/Dockerfile
+++ b/dockerfiles/css/Dockerfile
@@ -1,0 +1,26 @@
+FROM golang:1.10-alpine
+WORKDIR /go/src/github.com/sourcegraph/lsp-adapter
+COPY . .
+RUN CGO_ENABLED=0 GOBIN=/usr/local/bin go install github.com/sourcegraph/lsp-adapter
+
+# 👀 Add steps here to build the language server itself 👀
+# CMD ["echo", "🚨 This statement should be removed once you have added the logic to start up the language server! 🚨 Exiting..."]
+
+FROM node:9
+
+# Use tini as entrypoint to correctly handle signals and zombie processes.
+ENV TINI_VERSION v0.18.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+ENTRYPOINT ["/tini", "--"]
+
+USER node
+# see https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md#global-npm-dependencies
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+ENV PATH=$PATH:/home/node/.npm-global/bin
+RUN npm i -g vscode-css-languageserver-bin
+
+COPY --from=0 /usr/local/bin/lsp-adapter /usr/local/bin
+EXPOSE 8080
+# Modify this command to connect to the language server
+CMD ["lsp-adapter", "--trace", "--didOpenLanguage='css'", "--proxyAddress=0.0.0.0:8080", "css-languageserver", "--stdio"]


### PR DESCRIPTION
![](https://cl.ly/3d3b1V0g1y2Q/Screen%20Recording%202018-04-27%20at%2011.36%20AM.gif)

LS: https://github.com/vscode-langservers/vscode-css-languageserver-bin

Note that this needs the `didOpen` hack. This might be an issue with `css` versus `scss`, etc...

cc @keegancsmith 