### PR TITLE
Add glob flag

### DIFF
--- a/dockerfiles/docker/Dockerfile
+++ b/dockerfiles/docker/Dockerfile
@@ -5,11 +5,9 @@ RUN CGO_ENABLED=0 GOBIN=/usr/local/bin go install github.com/sourcegraph/lsp-ada
 
 FROM rcjsuen/docker-langserver
 
-ENV TINI_VERSION v0.18.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
-RUN chmod +x /tini
-ENTRYPOINT ["/tini", "--"]
+RUN apk add --no-cache tini
+ENTRYPOINT ["tini", "--"]
 
 COPY --from=0 /usr/local/bin/lsp-adapter /usr/local/bin/
 EXPOSE 8080
-CMD ["lsp-adapter", "--proxyAddress=0.0.0.0:8080", "/docker-langserver/bin/docker-langserver", "--stdio"]
+CMD ["lsp-adapter", "-proxyAddress=0.0.0.0:8080", "-glob=Dockerfile*", "/docker-langserver/bin/docker-langserver", "--stdio"]

--- a/proxy.go
+++ b/proxy.go
@@ -13,6 +13,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 
@@ -28,6 +29,7 @@ var (
 	cacheDir          = flag.String("cacheDirectory", filepath.Join(os.TempDir(), "proxy-cache"), "cache directory location")
 	didOpenLanguage   = flag.String("didOpenLanguage", "", "(HACK) If non-empty, send 'textDocument/didOpen' notifications with the specified language field (e.x. 'python') to the language server for every file.")
 	jsonrpc2IDRewrite = flag.String("jsonrpc2IDRewrite", "none", "(HACK) Rewrite jsonrpc2 ID. none (default) is no rewriting. string will use a string ID. number will use number ID. Useful for language servers with non-spec complaint JSONRPC2 implementations.")
+	glob              = flag.String("glob", "", "A colon (:) separated list of file globs to sync locally. By default we place all files into the workspace, but some language servers may only look at a subset of files. Specifying this allows us to avoid syncing all files. Note: This is done base name only.")
 	trace             = flag.Bool("trace", false, "trace logs to stderr")
 )
 
@@ -180,7 +182,8 @@ func (p *cloneProxy) handleClientRequest(ctx context.Context, conn *jsonrpc2.Con
 	<-p.ready
 
 	if req.Method == "initialize" {
-		if err := p.cloneWorkspaceToCache(); err != nil {
+		globs := strings.Split(*glob, ":")
+		if err := p.cloneWorkspaceToCache(globs); err != nil {
 			log.Println("CloneProxy.handleClientRequest(): cloning workspace failed during initialize", err)
 			return
 		}

--- a/remote_fs_test.go
+++ b/remote_fs_test.go
@@ -56,7 +56,7 @@ func TestClone(t *testing.T) {
 	defer os.Remove(baseDir)
 
 	runTest(t, files, func(ctx context.Context, fs *remoteFS) {
-		err := fs.Clone(ctx, baseDir)
+		err := fs.Clone(ctx, baseDir, nil)
 
 		if err != nil {
 			t.Errorf("when calling clone(baseDir=%s): %v", baseDir, err)

--- a/uris.go
+++ b/uris.go
@@ -15,9 +15,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (p *cloneProxy) cloneWorkspaceToCache() error {
+func (p *cloneProxy) cloneWorkspaceToCache(globs []string) error {
 	fs := &remoteFS{conn: p.client}
-	err := fs.Clone(p.ctx, p.workspaceCacheDir())
+	err := fs.Clone(p.ctx, p.workspaceCacheDir(), globs)
 	if err != nil {
 		return errors.Wrap(err, "failed to clone workspace to local cache")
 	}


### PR DESCRIPTION
For language servers which never scan the directory, this allows us to avoid
syncing many files. For example, most repositories only contain one Dockerfile
and the dockerfile LS only ever reads Dockerfiles. This allows us to very
quickly bootstrap the workspace.