### PR TITLE
glob: use string.FieldsFunc instead of strings.Split

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -182,7 +182,7 @@ func (p *cloneProxy) handleClientRequest(ctx context.Context, conn *jsonrpc2.Con
 	<-p.ready
 
 	if req.Method == "initialize" {
-		globs := strings.Split(*glob, ":")
+		globs := strings.FieldsFunc(*glob, func(r rune) bool { return r == ':' })
 		if err := p.cloneWorkspaceToCache(globs); err != nil {
 			log.Println("CloneProxy.handleClientRequest(): cloning workspace failed during initialize", err)
 			return


### PR DESCRIPTION
using string.Split left empty glob patterns, which isn't what we want

i.e. `strings.Split("", ":") -> [""]`, `strings.FieldsFunc("", func(r rune) bool { r == ':') -> []`