### PR TITLE
lsp-record: Allow specifying a testcase name

### DIFF
--- a/internal/cmd/lsp-record/lsp-record.go
+++ b/internal/cmd/lsp-record/lsp-record.go
@@ -444,7 +444,7 @@ func mainErr() error {
 	}
 	if testcase != "-" && !exists(testdataDir) {
 		if err := os.MkdirAll(testdataDir, os.ModePerm); err != nil {
-			return err
+			return errors.Wrapf(err, "error creating testdata directory for %s", lang)
 		}
 	}
 
@@ -476,7 +476,7 @@ func mainErr() error {
 		}
 		fd, err := fileCreateNotExist(filepath.Join(testdataDir, testcase+".input.json"))
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "error writing to %s.input.json", testcase)
 		}
 		defer fd.Close()
 		return record(io.MultiWriter(fd, os.Stdout))
@@ -488,12 +488,12 @@ func mainErr() error {
 	}
 	input, err := os.Open(filepath.Join(testdataDir, testcase+".input.json"))
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "error opening %s.input.json", testcase)
 	}
 	defer input.Close()
 	output, err := os.Create(filepath.Join(testdataDir, testcase+".golden.json"))
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "error writing output to %s.golden.json", testcase)
 	}
 	defer output.Close()
 	return test(input, io.MultiWriter(output, os.Stdout))


### PR DESCRIPTION
To simplify saving the testdata we allow a testcase name to be passed as an
argument. Instead of stdin and stdout, a .input.json and/or .golden.json file
is used instead.

Right now lsp-record test will always write to the files, and not actually
"test" by comparing to the golden output. For now this is fine since we expect
the files to be checked in, and can be added as a follow-up PR.