### PR TITLE
Reduce csharp image size from ~2 GB to ~1 GB

### DIFF
--- a/dockerfiles/csharp/Dockerfile
+++ b/dockerfiles/csharp/Dockerfile
@@ -19,6 +19,8 @@ RUN apt-get update \
   && apt-get update && apt-get install -y apt-transport-https \
   # OmniSharp runs on Mono and requires the .NET SDK 2.0.0.
   && apt-get update && apt-get install -y mono-complete dotnet-sdk-2.0.0 nodejs \
+  # Removes ~1 GB of unused files.
+  && rm -rf /usr/share/dotnet/sdk/NuGetFallbackFolder \
   # omnisharp-client translates between LSP and OmniSharp's custom protocol.
   && npm install -g omnisharp-client@7.2.3
 


### PR DESCRIPTION
The `NuGetFallbackFolder` directory was taking ~1 GB of space in the docker image, but it wasn't being used (or, at least code intelligence works without it).

One other person has [removed `NuGetFallbackFolder` in their Dockerfile](https://github.com/justinchizer/ndn2/blob/f742c42abc3c398fe21d642bbc866bb9dc0eccfb/src/docker-worker/dotnet-slim/Dockerfile#L30), so this seems moderately safe.