### PR TITLE
Include -v /var/run/docker.sock:/var/run/docker.sock in the instructions

### DIFF
--- a/dockerfiles/bash/README.md
+++ b/dockerfiles/bash/README.md
@@ -17,7 +17,7 @@ Thanks to the [mads-hartmann/bash-language-server](https://github.com/mads-hartm
 1. Run the `sourcegarph/server` Docker image: 
 
 ```shell
-docker run --publish 7080:7080 --rm --network=lsp --name=sourcegraph --volume ~/.sourcegraph/config:/etc/sourcegraph --volume ~/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:2.7.6
+docker run --publish 7080:7080 --rm --network=lsp --name=sourcegraph --volume ~/.sourcegraph/config:/etc/sourcegraph --volume ~/.sourcegraph/data:/var/opt/sourcegraph -v /var/run/docker.sock:/var/run/docker.sock sourcegraph/server:2.7.6
 ```
 
 2. Run the experimental Bash language server:

--- a/dockerfiles/clojure/README.md
+++ b/dockerfiles/clojure/README.md
@@ -17,7 +17,7 @@ Thanks to the [snoe/clojure-lsp](https://github.com/snoe/clojure-lsp) project fo
 1. Run the `sourcegarph/server` Docker image: 
 
 ```shell
-docker run --publish 7080:7080 --rm --network=lsp --name=sourcegraph --volume ~/.sourcegraph/config:/etc/sourcegraph --volume ~/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:2.7.6
+docker run --publish 7080:7080 --rm --network=lsp --name=sourcegraph --volume ~/.sourcegraph/config:/etc/sourcegraph --volume ~/.sourcegraph/data:/var/opt/sourcegraph -v /var/run/docker.sock:/var/run/docker.sock sourcegraph/server:2.7.6
 ```
 
 2. Run the experimental Clojure language server:

--- a/dockerfiles/cpp/README.md
+++ b/dockerfiles/cpp/README.md
@@ -17,7 +17,7 @@ Thanks to [LLVM](https://clang.llvm.org/extra/clangd.html) (and [Chilledheart/vi
 1. Run the `sourcegarph/server` Docker image: 
 
 ```shell
-docker run --publish 7080:7080 --rm --network=lsp --name=sourcegraph --volume ~/.sourcegraph/config:/etc/sourcegraph --volume ~/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:2.7.6
+docker run --publish 7080:7080 --rm --network=lsp --name=sourcegraph --volume ~/.sourcegraph/config:/etc/sourcegraph --volume ~/.sourcegraph/data:/var/opt/sourcegraph -v /var/run/docker.sock:/var/run/docker.sock sourcegraph/server:2.7.6
 ```
 
 2. Run the experimental C++ language server:

--- a/dockerfiles/csharp/README.md
+++ b/dockerfiles/csharp/README.md
@@ -17,7 +17,7 @@ Thanks to the [OmniSharp/omnisharp-node-client](https://github.com/OmniSharp/omn
 1. Run the `sourcegarph/server` Docker image:
 
 ```shell
-docker run --publish 7080:7080 --rm --network=lsp --name=sourcegraph --volume ~/.sourcegraph/config:/etc/sourcegraph --volume ~/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:2.7.6
+docker run --publish 7080:7080 --rm --network=lsp --name=sourcegraph --volume ~/.sourcegraph/config:/etc/sourcegraph --volume ~/.sourcegraph/data:/var/opt/sourcegraph -v /var/run/docker.sock:/var/run/docker.sock sourcegraph/server:2.7.6
 ```
 
 2. Run the experimental C# language server:

--- a/dockerfiles/css/README.md
+++ b/dockerfiles/css/README.md
@@ -17,7 +17,7 @@ Thanks to the [Microsoft/vscode](https://github.com/Microsoft/vscode/) project (
 1. Run the `sourcegarph/server` Docker image: 
 
 ```shell
-docker run --publish 7080:7080 --rm --network=lsp --name=sourcegraph --volume ~/.sourcegraph/config:/etc/sourcegraph --volume ~/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:2.7.6
+docker run --publish 7080:7080 --rm --network=lsp --name=sourcegraph --volume ~/.sourcegraph/config:/etc/sourcegraph --volume ~/.sourcegraph/data:/var/opt/sourcegraph -v /var/run/docker.sock:/var/run/docker.sock sourcegraph/server:2.7.6
 ```
 
 2. Run the experimental CSS language server:

--- a/dockerfiles/docker/README.md
+++ b/dockerfiles/docker/README.md
@@ -19,7 +19,7 @@ Thanks to the [rcjsuen/dockerfile-language-server-nodejs](https://github.com/rcj
 1. Run the `sourcegarph/server` Docker image: 
 
 ```shell
-docker run --publish 7080:7080 --rm --network=lsp --name=sourcegraph --volume ~/.sourcegraph/config:/etc/sourcegraph --volume ~/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:2.7.6
+docker run --publish 7080:7080 --rm --network=lsp --name=sourcegraph --volume ~/.sourcegraph/config:/etc/sourcegraph --volume ~/.sourcegraph/data:/var/opt/sourcegraph -v /var/run/docker.sock:/var/run/docker.sock sourcegraph/server:2.7.6
 ```
 
 2. Run the experimental Dockerfile language server:

--- a/dockerfiles/elixir/README.md
+++ b/dockerfiles/elixir/README.md
@@ -19,7 +19,7 @@ Thanks to the [JakeBecker/elixir-ls](https://github.com/JakeBecker/elixir-ls) pr
 1. Run the `sourcegarph/server` Docker image: 
 
 ```shell
-docker run --publish 7080:7080 --rm --network=lsp --name=sourcegraph --volume ~/.sourcegraph/config:/etc/sourcegraph --volume ~/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:2.7.6
+docker run --publish 7080:7080 --rm --network=lsp --name=sourcegraph --volume ~/.sourcegraph/config:/etc/sourcegraph --volume ~/.sourcegraph/data:/var/opt/sourcegraph -v /var/run/docker.sock:/var/run/docker.sock sourcegraph/server:2.7.6
 ```
 
 2. Run the experimental Elixir language server:

--- a/dockerfiles/html/README.md
+++ b/dockerfiles/html/README.md
@@ -17,7 +17,7 @@ Thanks to the [Microsoft/vscode](https://github.com/Microsoft/vscode/) project (
 1. Run the `sourcegarph/server` Docker image: 
 
 ```shell
-docker run --publish 7080:7080 --rm --network=lsp --name=sourcegraph --volume ~/.sourcegraph/config:/etc/sourcegraph --volume ~/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:2.7.6
+docker run --publish 7080:7080 --rm --network=lsp --name=sourcegraph --volume ~/.sourcegraph/config:/etc/sourcegraph --volume ~/.sourcegraph/data:/var/opt/sourcegraph -v /var/run/docker.sock:/var/run/docker.sock sourcegraph/server:2.7.6
 ```
 
 2. Run the experimental HTML language server:

--- a/dockerfiles/ocaml/README.md
+++ b/dockerfiles/ocaml/README.md
@@ -17,7 +17,7 @@ Thanks to the [freebroccolo/ocaml-language-server](https://github.com/freebrocco
 1. Run the `sourcegarph/server` Docker image: 
 
 ```shell
-docker run --publish 7080:7080 --rm --network=lsp --name=sourcegraph --volume ~/.sourcegraph/config:/etc/sourcegraph --volume ~/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:2.7.6
+docker run --publish 7080:7080 --rm --network=lsp --name=sourcegraph --volume ~/.sourcegraph/config:/etc/sourcegraph --volume ~/.sourcegraph/data:/var/opt/sourcegraph -v /var/run/docker.sock:/var/run/docker.sock sourcegraph/server:2.7.6
 ```
 
 2. Run the experimental Dockerfile language server:

--- a/dockerfiles/ruby/README.md
+++ b/dockerfiles/ruby/README.md
@@ -17,7 +17,7 @@ Thanks to the [castwide/solargraph](https://github.com/castwide/solargraph) proj
 1. Run the `sourcegarph/server` Docker image: 
 
 ```shell
-docker run --publish 7080:7080 --rm --network=lsp --name=sourcegraph --volume ~/.sourcegraph/config:/etc/sourcegraph --volume ~/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:2.7.6
+docker run --publish 7080:7080 --rm --network=lsp --name=sourcegraph --volume ~/.sourcegraph/config:/etc/sourcegraph --volume ~/.sourcegraph/data:/var/opt/sourcegraph -v /var/run/docker.sock:/var/run/docker.sock sourcegraph/server:2.7.6
 ```
 
 2. Run the experimental Dockerfile language server:

--- a/dockerfiles/rust/README.md
+++ b/dockerfiles/rust/README.md
@@ -17,7 +17,7 @@ Thanks to the [rust-lang-nursery/rls](https://github.com/rust-lang-nursery/rls) 
 1. Run the `sourcegarph/server` Docker image: 
 
 ```shell
-docker run --publish 7080:7080 --rm --network=lsp --name=sourcegraph --volume ~/.sourcegraph/config:/etc/sourcegraph --volume ~/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:2.7.6
+docker run --publish 7080:7080 --rm --network=lsp --name=sourcegraph --volume ~/.sourcegraph/config:/etc/sourcegraph --volume ~/.sourcegraph/data:/var/opt/sourcegraph -v /var/run/docker.sock:/var/run/docker.sock sourcegraph/server:2.7.6
 ```
 
 2. Run the experimental Dockerfile language server:


### PR DESCRIPTION
This allows Sourcegraph to pull images and run containers.