### PR TITLE
Fix the Lua build

### DIFF
--- a/dockerfiles/lua/Dockerfile
+++ b/dockerfiles/lua/Dockerfile
@@ -8,7 +8,7 @@ RUN CGO_ENABLED=0 GOBIN=/usr/local/bin go install github.com/sourcegraph/lsp-ada
 
 FROM abaez/luarocks:lua5.1
 
-RUN apk add --no-cache ca-certificates=20171114-r0 git=2.15.0-r1 tini=0.16.1-r0
+RUN apk add --no-cache ca-certificates=20161130-r2 git=2.13.5-r0 tini=0.14.0-r0
 
 ENTRYPOINT ["/sbin/tini", "--"]
 


### PR DESCRIPTION
The Lua build failed due to incompatible versions of installed `apk` packages: https://travis-ci.org/sourcegraph/lsp-adapter/jobs/378625112

This happened because I copy-pasta'd the versions from another Dockerfile without verifying they worked 😞 

This could be avoided in the future by building images on PRs too (not just master).