### PR TITLE
Remove manual installation instructions and refer to about.sourcegraph.com/docs

### DIFF
--- a/dockerfiles/bash/README.md
+++ b/dockerfiles/bash/README.md
@@ -10,4 +10,4 @@ This Dockerfile adds experimental Bash language support for Sourcegraph.
 
 Thanks to the [mads-hartmann/bash-language-server](https://github.com/mads-hartmann/bash-language-server) project for providing the language server that's wrapped by `lsp-adapter` in this image.
 
-Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/experimental-languages) for information on enabling this language server for your Sourcegraph installation.
+Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/experimental-language-servers) for information on enabling this language server for your Sourcegraph installation.

--- a/dockerfiles/bash/README.md
+++ b/dockerfiles/bash/README.md
@@ -10,43 +10,4 @@ This Dockerfile adds experimental Bash language support for Sourcegraph.
 
 Thanks to the [mads-hartmann/bash-language-server](https://github.com/mads-hartmann/bash-language-server) project for providing the language server that's wrapped by `lsp-adapter` in this image.
 
-## How to add this language server to Sourcegraph
-
-*These steps are adapted from our documentation for [manually adding code intelligence to Sourcegraph server](https://about.sourcegraph.com/docs/code-intelligence/install-manual/).*
-
-1. Run the `sourcegarph/server` Docker image: 
-
-```shell
-docker run --publish 7080:7080 --rm --network=lsp --name=sourcegraph --volume ~/.sourcegraph/config:/etc/sourcegraph --volume ~/.sourcegraph/data:/var/opt/sourcegraph -v /var/run/docker.sock:/var/run/docker.sock sourcegraph/server:2.7.6
-```
-
-2. Run the experimental Bash language server:
-
-  ```shell
-  docker pull sourcegraph/codeintel-bash
-
-  docker run --rm --network=lsp --name=bash sourcegraph/codeintel-bash
-  ```
-
-3. Add the following entry to the `langservers` field in the [site configuration](https://about.sourcegraph.com/docs/config):
-
-  ```js
-  {
-      // ...
-      "langservers": [
-          // ...
-          {
-              "language": "bash",
-              "address": "tcp://bash:8080",
-              "metadata": {
-                "experimental": true,
-                "homepageURL": "https://github.com/mads-hartmann/bash-language-server", 
-                "issuesURL": "https://github.com/mads-hartmann/bash-language-server/issues", 
-                "docsURL": "https://github.com/mads-hartmann/bash-language-server/blob/master/README.md"
-              }
-          },
-          // ...
-      ]
-      // ...
-  }
-  ```
+Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/preview-languages) for information on enabling this language server for your Sourcegraph installation.

--- a/dockerfiles/bash/README.md
+++ b/dockerfiles/bash/README.md
@@ -10,4 +10,4 @@ This Dockerfile adds experimental Bash language support for Sourcegraph.
 
 Thanks to the [mads-hartmann/bash-language-server](https://github.com/mads-hartmann/bash-language-server) project for providing the language server that's wrapped by `lsp-adapter` in this image.
 
-Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/preview-languages) for information on enabling this language server for your Sourcegraph installation.
+Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/experimental-languages) for information on enabling this language server for your Sourcegraph installation.

--- a/dockerfiles/clojure/README.md
+++ b/dockerfiles/clojure/README.md
@@ -10,43 +10,4 @@ This Dockerfile adds experimental Clojure language support for Sourcegraph.
 
 Thanks to the [snoe/clojure-lsp](https://github.com/snoe/clojure-lsp) project for providing the language server that's wrapped by `lsp-adapter` in this image.
 
-## How to add this language server to Sourcegraph
-
-*These steps are adapted from our documentation for [manually adding code intelligence to Sourcegraph server](https://about.sourcegraph.com/docs/code-intelligence/install-manual/).*
-
-1. Run the `sourcegarph/server` Docker image: 
-
-```shell
-docker run --publish 7080:7080 --rm --network=lsp --name=sourcegraph --volume ~/.sourcegraph/config:/etc/sourcegraph --volume ~/.sourcegraph/data:/var/opt/sourcegraph -v /var/run/docker.sock:/var/run/docker.sock sourcegraph/server:2.7.6
-```
-
-2. Run the experimental Clojure language server:
-
-  ```shell
-  docker pull sourcegraph/codeintel-clojure
-
-  docker run --rm --network=lsp --name=clojure sourcegraph/codeintel-clojure
-  ```
-
-3. Add the following entry to the `langservers` field in the [site configuration](https://about.sourcegraph.com/docs/config):
-
-  ```js
-  {
-      // ...
-      "langservers": [
-          // ...
-          {
-              "language": "clojure",
-              "address": "tcp://clojure:8080",
-              "metadata": {
-                "experimental": true,
-                "homepageURL": "https://github.com/snoe/clojure-lsp", 
-                "issuesURL": "https://github.com/snoe/clojure-lsp/issues", 
-                "docsURL": "https://github.com/snoe/clojure-lsp/blob/master/README.md"
-              }
-          },
-          // ...
-      ]
-      // ...
-  }
-  ```
+Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/preview-languages) for information on enabling this language server for your Sourcegraph installation.

--- a/dockerfiles/clojure/README.md
+++ b/dockerfiles/clojure/README.md
@@ -10,4 +10,4 @@ This Dockerfile adds experimental Clojure language support for Sourcegraph.
 
 Thanks to the [snoe/clojure-lsp](https://github.com/snoe/clojure-lsp) project for providing the language server that's wrapped by `lsp-adapter` in this image.
 
-Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/experimental-languages) for information on enabling this language server for your Sourcegraph installation.
+Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/experimental-language-servers) for information on enabling this language server for your Sourcegraph installation.

--- a/dockerfiles/clojure/README.md
+++ b/dockerfiles/clojure/README.md
@@ -10,4 +10,4 @@ This Dockerfile adds experimental Clojure language support for Sourcegraph.
 
 Thanks to the [snoe/clojure-lsp](https://github.com/snoe/clojure-lsp) project for providing the language server that's wrapped by `lsp-adapter` in this image.
 
-Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/preview-languages) for information on enabling this language server for your Sourcegraph installation.
+Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/experimental-languages) for information on enabling this language server for your Sourcegraph installation.

--- a/dockerfiles/cpp/README.md
+++ b/dockerfiles/cpp/README.md
@@ -10,4 +10,4 @@ This Dockerfile adds experimental C++ language support for Sourcegraph.
 
 Thanks to [LLVM](https://clang.llvm.org/extra/clangd.html) (and [Chilledheart/vim-clangd](https://github.com/Chilledheart/vim-clangd) for providing prebuilt binaries) for providing the language server that's wrapped by `lsp-adapter` in this image.
 
-Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/preview-languages) for information on enabling this language server for your Sourcegraph installation.
+Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/experimental-languages) for information on enabling this language server for your Sourcegraph installation.

--- a/dockerfiles/cpp/README.md
+++ b/dockerfiles/cpp/README.md
@@ -10,4 +10,4 @@ This Dockerfile adds experimental C++ language support for Sourcegraph.
 
 Thanks to [LLVM](https://clang.llvm.org/extra/clangd.html) (and [Chilledheart/vim-clangd](https://github.com/Chilledheart/vim-clangd) for providing prebuilt binaries) for providing the language server that's wrapped by `lsp-adapter` in this image.
 
-Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/experimental-languages) for information on enabling this language server for your Sourcegraph installation.
+Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/experimental-language-servers) for information on enabling this language server for your Sourcegraph installation.

--- a/dockerfiles/cpp/README.md
+++ b/dockerfiles/cpp/README.md
@@ -10,43 +10,4 @@ This Dockerfile adds experimental C++ language support for Sourcegraph.
 
 Thanks to [LLVM](https://clang.llvm.org/extra/clangd.html) (and [Chilledheart/vim-clangd](https://github.com/Chilledheart/vim-clangd) for providing prebuilt binaries) for providing the language server that's wrapped by `lsp-adapter` in this image.
 
-## How to add this language server to Sourcegraph
-
-*These steps are adapted from our documentation for [manually adding code intelligence to Sourcegraph server](https://about.sourcegraph.com/docs/code-intelligence/install-manual/).*
-
-1. Run the `sourcegarph/server` Docker image: 
-
-```shell
-docker run --publish 7080:7080 --rm --network=lsp --name=sourcegraph --volume ~/.sourcegraph/config:/etc/sourcegraph --volume ~/.sourcegraph/data:/var/opt/sourcegraph -v /var/run/docker.sock:/var/run/docker.sock sourcegraph/server:2.7.6
-```
-
-2. Run the experimental C++ language server:
-
-  ```shell
-  docker pull sourcegraph/codeintel-cpp
-
-  docker run --rm --network=lsp --name=cpp sourcegraph/codeintel-cpp
-  ```
-
-3. Add the following entry to the `langservers` field in the [site configuration](https://about.sourcegraph.com/docs/config):
-
-  ```js
-  {
-      // ...
-      "langservers": [
-          // ...
-          {
-              "language": "cpp",
-              "address": "tcp://cpp:8080",
-              "metadata": {
-                "experimental": true,
-                "homepageURL": "https://clang.llvm.org/extra/clangd.html", 
-                "issuesURL": "https://bugs.llvm.org/buglist.cgi?quicksearch=clangd", 
-                "docsURL": "https://clang.llvm.org/extra/clangd.html"
-              }
-          },
-          // ...
-      ]
-      // ...
-  }
-  ```
+Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/preview-languages) for information on enabling this language server for your Sourcegraph installation.

--- a/dockerfiles/csharp/README.md
+++ b/dockerfiles/csharp/README.md
@@ -10,43 +10,4 @@ This Dockerfile adds experimental C# language support for Sourcegraph.
 
 Thanks to the [OmniSharp/omnisharp-node-client](https://github.com/OmniSharp/omnisharp-node-client) project for providing the language server that's wrapped by `lsp-adapter` in this image.
 
-## How to add this language server to Sourcegraph
-
-*These steps are adapted from our documentation for [manually adding code intelligence to Sourcegraph server](https://about.sourcegraph.com/docs/code-intelligence/install-manual/).*
-
-1. Run the `sourcegarph/server` Docker image:
-
-```shell
-docker run --publish 7080:7080 --rm --network=lsp --name=sourcegraph --volume ~/.sourcegraph/config:/etc/sourcegraph --volume ~/.sourcegraph/data:/var/opt/sourcegraph -v /var/run/docker.sock:/var/run/docker.sock sourcegraph/server:2.7.6
-```
-
-2. Run the experimental C# language server:
-
-  ```shell
-  docker pull sourcegraph/codeintel-csharp
-
-  docker run --rm --network=lsp --name=csharp sourcegraph/codeintel-csharp
-  ```
-
-3. Add the following entry to the `langservers` field in the [site configuration](https://about.sourcegraph.com/docs/config):
-
-  ```js
-  {
-      // ...
-      "langservers": [
-          // ...
-          {
-              "language": "cs",
-              "address": "tcp://csharp:8080",
-              "metadata": {
-                "experimental": true,
-                "homepageURL": "https://github.com/OmniSharp/omnisharp-node-client",
-                "issuesURL": "https://github.com/OmniSharp/omnisharp-node-client/issues",
-                "docsURL": "https://github.com/OmniSharp/omnisharp-node-client/blob/master/README.md"
-              }
-          },
-          // ...
-      ]
-      // ...
-  }
-  ```
+Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/preview-languages) for information on enabling this language server for your Sourcegraph installation.

--- a/dockerfiles/csharp/README.md
+++ b/dockerfiles/csharp/README.md
@@ -10,4 +10,4 @@ This Dockerfile adds experimental C# language support for Sourcegraph.
 
 Thanks to the [OmniSharp/omnisharp-node-client](https://github.com/OmniSharp/omnisharp-node-client) project for providing the language server that's wrapped by `lsp-adapter` in this image.
 
-Check out the [Sourcegraph docs](https://about.sourcegraph.com/docs/code-intelligence/experimental-languages) for information on enabling this language server for your Sourcegraph installation.
+Check out the [Sourcegraph docs](https://about.sourcegraph.com/docs/code-intelligence/experimental-language-servers) for information on enabling this language server for your Sourcegraph installation.

--- a/dockerfiles/csharp/README.md
+++ b/dockerfiles/csharp/README.md
@@ -10,4 +10,4 @@ This Dockerfile adds experimental C# language support for Sourcegraph.
 
 Thanks to the [OmniSharp/omnisharp-node-client](https://github.com/OmniSharp/omnisharp-node-client) project for providing the language server that's wrapped by `lsp-adapter` in this image.
 
-Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/preview-languages) for information on enabling this language server for your Sourcegraph installation.
+Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/experimental-languages) for information on enabling this language server for your Sourcegraph installation.

--- a/dockerfiles/csharp/README.md
+++ b/dockerfiles/csharp/README.md
@@ -10,4 +10,4 @@ This Dockerfile adds experimental C# language support for Sourcegraph.
 
 Thanks to the [OmniSharp/omnisharp-node-client](https://github.com/OmniSharp/omnisharp-node-client) project for providing the language server that's wrapped by `lsp-adapter` in this image.
 
-Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/experimental-languages) for information on enabling this language server for your Sourcegraph installation.
+Check out the [Sourcegraph docs](https://about.sourcegraph.com/docs/code-intelligence/experimental-languages) for information on enabling this language server for your Sourcegraph installation.

--- a/dockerfiles/css/README.md
+++ b/dockerfiles/css/README.md
@@ -10,43 +10,4 @@ This Dockerfile adds experimental CSS language support for Sourcegraph.
 
 Thanks to the [Microsoft/vscode](https://github.com/Microsoft/vscode/) project (and [vscode-langservers/vscode-css-languageserver-bin](https://github.com/vscode-langservers/vscode-css-languageserver-bin) for providing prebuilt binaries) for providing the language server that's wrapped by `lsp-adapter` in this image.
 
-## How to add this language server to Sourcegraph
-
-*These steps are adapted from our documentation for [manually adding code intelligence to Sourcegraph server](https://about.sourcegraph.com/docs/code-intelligence/install-manual/).*
-
-1. Run the `sourcegarph/server` Docker image: 
-
-```shell
-docker run --publish 7080:7080 --rm --network=lsp --name=sourcegraph --volume ~/.sourcegraph/config:/etc/sourcegraph --volume ~/.sourcegraph/data:/var/opt/sourcegraph -v /var/run/docker.sock:/var/run/docker.sock sourcegraph/server:2.7.6
-```
-
-2. Run the experimental CSS language server:
-
-  ```shell
-  docker pull sourcegraph/codeintel-css
-
-  docker run --rm --network=lsp --name=css sourcegraph/codeintel-css
-  ```
-
-3. Add the following entry to the `langservers` field in the [site configuration](https://about.sourcegraph.com/docs/config):
-
-  ```js
-  {
-      // ...
-      "langservers": [
-          // ...
-          {
-              "language": "css",
-              "address": "tcp://css:8080",
-              "metadata": {
-                "experimental": true,
-                "homepageURL": "https://github.com/Microsoft/vscode", 
-                "issuesURL": "https://github.com/Microsoft/vscode/issues", 
-                "docsURL": "https://github.com/Microsoft/vscode/blob/master/README.md"
-              }
-          },
-          // ...
-      ]
-      // ...
-  }
-  ```
+Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/preview-languages) for information on enabling this language server for your Sourcegraph installation.

--- a/dockerfiles/css/README.md
+++ b/dockerfiles/css/README.md
@@ -10,4 +10,4 @@ This Dockerfile adds experimental CSS language support for Sourcegraph.
 
 Thanks to the [Microsoft/vscode](https://github.com/Microsoft/vscode/) project (and [vscode-langservers/vscode-css-languageserver-bin](https://github.com/vscode-langservers/vscode-css-languageserver-bin) for providing prebuilt binaries) for providing the language server that's wrapped by `lsp-adapter` in this image.
 
-Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/experimental-languages) for information on enabling this language server for your Sourcegraph installation.
+Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/experimental-language-servers) for information on enabling this language server for your Sourcegraph installation.

--- a/dockerfiles/css/README.md
+++ b/dockerfiles/css/README.md
@@ -10,4 +10,4 @@ This Dockerfile adds experimental CSS language support for Sourcegraph.
 
 Thanks to the [Microsoft/vscode](https://github.com/Microsoft/vscode/) project (and [vscode-langservers/vscode-css-languageserver-bin](https://github.com/vscode-langservers/vscode-css-languageserver-bin) for providing prebuilt binaries) for providing the language server that's wrapped by `lsp-adapter` in this image.
 
-Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/preview-languages) for information on enabling this language server for your Sourcegraph installation.
+Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/experimental-languages) for information on enabling this language server for your Sourcegraph installation.

--- a/dockerfiles/docker/README.md
+++ b/dockerfiles/docker/README.md
@@ -12,4 +12,4 @@ This Dockerfile adds experimental Dockerfile language support for Sourcegraph.
 
 Thanks to the [rcjsuen/dockerfile-language-server-nodejs](https://github.com/rcjsuen/dockerfile-language-server-nodejs) project for providing the language server that's wrapped by `lsp-adapter` in this image.
 
-Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/preview-languages) for information on enabling this language server for your Sourcegraph installation.
+Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/experimental-languages) for information on enabling this language server for your Sourcegraph installation.

--- a/dockerfiles/docker/README.md
+++ b/dockerfiles/docker/README.md
@@ -12,43 +12,4 @@ This Dockerfile adds experimental Dockerfile language support for Sourcegraph.
 
 Thanks to the [rcjsuen/dockerfile-language-server-nodejs](https://github.com/rcjsuen/dockerfile-language-server-nodejs) project for providing the language server that's wrapped by `lsp-adapter` in this image.
 
-## How to add this language server to Sourcegraph
-
-*These steps are adapted from our documentation for [manually adding code intelligence to Sourcegraph server](https://about.sourcegraph.com/docs/code-intelligence/install-manual/).*
-
-1. Run the `sourcegarph/server` Docker image: 
-
-```shell
-docker run --publish 7080:7080 --rm --network=lsp --name=sourcegraph --volume ~/.sourcegraph/config:/etc/sourcegraph --volume ~/.sourcegraph/data:/var/opt/sourcegraph -v /var/run/docker.sock:/var/run/docker.sock sourcegraph/server:2.7.6
-```
-
-2. Run the experimental Dockerfile language server:
-
-  ```shell
-  docker pull sourcegraph/codeintel-docker
-
-  docker run --rm --network=lsp --name=dockerfile sourcegraph/codeintel-docker
-  ```
-
-3. Add the following entry to the `langservers` field in the [site configuration](https://about.sourcegraph.com/docs/config):
-
-  ```js
-  {
-      // ...
-      "langservers": [
-          // ...
-          {
-              "language": "dockerfile",
-              "address": "tcp://dockerfile:8080",
-              "metadata": {
-                "experimental": true,
-                "homepageURL": "https://github.com/rcjsuen/dockerfile-language-server-nodejs", 
-                "issuesURL": "https://github.com/rcjsuen/dockerfile-language-server-nodejs/issues", 
-                "docsURL": "https://github.com/rcjsuen/dockerfile-language-server-nodejs/blob/master/README.md"
-              }
-          },
-          // ...
-      ]
-      // ...
-  }
-  ```
+Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/preview-languages) for information on enabling this language server for your Sourcegraph installation.

--- a/dockerfiles/docker/README.md
+++ b/dockerfiles/docker/README.md
@@ -12,4 +12,4 @@ This Dockerfile adds experimental Dockerfile language support for Sourcegraph.
 
 Thanks to the [rcjsuen/dockerfile-language-server-nodejs](https://github.com/rcjsuen/dockerfile-language-server-nodejs) project for providing the language server that's wrapped by `lsp-adapter` in this image.
 
-Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/experimental-languages) for information on enabling this language server for your Sourcegraph installation.
+Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/experimental-language-servers) for information on enabling this language server for your Sourcegraph installation.

--- a/dockerfiles/elixir/README.md
+++ b/dockerfiles/elixir/README.md
@@ -12,4 +12,4 @@ This Dockerfile adds experimental Elixir language support for Sourcegraph.
 
 Thanks to the [JakeBecker/elixir-ls](https://github.com/JakeBecker/elixir-ls) project for providing the language server that's wrapped by `lsp-adapter` in this image.
 
-Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/experimental-languages) for information on enabling this language server for your Sourcegraph installation.
+Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/experimental-language-servers) for information on enabling this language server for your Sourcegraph installation.

--- a/dockerfiles/elixir/README.md
+++ b/dockerfiles/elixir/README.md
@@ -12,4 +12,4 @@ This Dockerfile adds experimental Elixir language support for Sourcegraph.
 
 Thanks to the [JakeBecker/elixir-ls](https://github.com/JakeBecker/elixir-ls) project for providing the language server that's wrapped by `lsp-adapter` in this image.
 
-Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/preview-languages) for information on enabling this language server for your Sourcegraph installation.
+Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/experimental-languages) for information on enabling this language server for your Sourcegraph installation.

--- a/dockerfiles/elixir/README.md
+++ b/dockerfiles/elixir/README.md
@@ -12,43 +12,4 @@ This Dockerfile adds experimental Elixir language support for Sourcegraph.
 
 Thanks to the [JakeBecker/elixir-ls](https://github.com/JakeBecker/elixir-ls) project for providing the language server that's wrapped by `lsp-adapter` in this image.
 
-## How to add this language server to Sourcegraph
-
-*These steps are adapted from our documentation for [manually adding code intelligence to Sourcegraph server](https://about.sourcegraph.com/docs/code-intelligence/install-manual/).*
-
-1. Run the `sourcegarph/server` Docker image: 
-
-```shell
-docker run --publish 7080:7080 --rm --network=lsp --name=sourcegraph --volume ~/.sourcegraph/config:/etc/sourcegraph --volume ~/.sourcegraph/data:/var/opt/sourcegraph -v /var/run/docker.sock:/var/run/docker.sock sourcegraph/server:2.7.6
-```
-
-2. Run the experimental Elixir language server:
-
-  ```shell
-  docker pull sourcegraph/codeintel-elixir
-
-  docker run --rm --network=lsp --name=elixir sourcegraph/codeintel-elixir
-  ```
-
-3. Add the following entry to the `langservers` field in the [site configuration](https://about.sourcegraph.com/docs/config):
-
-  ```js
-  {
-      // ...
-      "langservers": [
-          // ...
-          {
-              "language": "elixir",
-              "address": "tcp://elixir:8080",
-              "metadata": {
-                "experimental": true,
-                "homepageURL": "https://github.com/JakeBecker/elixir-ls", 
-                "issuesURL": "https://github.com/JakeBecker/elixir-ls/issues", 
-                "docsURL": "https://github.com/JakeBecker/elixir-ls/blob/master/README.md"
-              }
-          },
-          // ...
-      ]
-      // ...
-  }
-  ```
+Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/preview-languages) for information on enabling this language server for your Sourcegraph installation.

--- a/dockerfiles/html/README.md
+++ b/dockerfiles/html/README.md
@@ -10,4 +10,4 @@ This Dockerfile adds experimental HTML language support for Sourcegraph.
 
 Thanks to the [Microsoft/vscode](https://github.com/Microsoft/vscode/) project (and [vscode-langservers/vscode-html-languageserver-bin](https://github.com/vscode-langservers/vscode-html-languageserver-bin) for providing prebuilt binaries) for providing the language server that's wrapped by `lsp-adapter` in this image.
 
-Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/preview-languages) for information on enabling this language server for your Sourcegraph installation.
+Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/experimental-languages) for information on enabling this language server for your Sourcegraph installation.

--- a/dockerfiles/html/README.md
+++ b/dockerfiles/html/README.md
@@ -10,4 +10,4 @@ This Dockerfile adds experimental HTML language support for Sourcegraph.
 
 Thanks to the [Microsoft/vscode](https://github.com/Microsoft/vscode/) project (and [vscode-langservers/vscode-html-languageserver-bin](https://github.com/vscode-langservers/vscode-html-languageserver-bin) for providing prebuilt binaries) for providing the language server that's wrapped by `lsp-adapter` in this image.
 
-Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/experimental-languages) for information on enabling this language server for your Sourcegraph installation.
+Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/experimental-language-servers) for information on enabling this language server for your Sourcegraph installation.

--- a/dockerfiles/html/README.md
+++ b/dockerfiles/html/README.md
@@ -10,43 +10,4 @@ This Dockerfile adds experimental HTML language support for Sourcegraph.
 
 Thanks to the [Microsoft/vscode](https://github.com/Microsoft/vscode/) project (and [vscode-langservers/vscode-html-languageserver-bin](https://github.com/vscode-langservers/vscode-html-languageserver-bin) for providing prebuilt binaries) for providing the language server that's wrapped by `lsp-adapter` in this image.
 
-## How to add this language server to Sourcegraph
-
-*These steps are adapted from our documentation for [manually adding code intelligence to Sourcegraph server](https://about.sourcegraph.com/docs/code-intelligence/install-manual/).*
-
-1. Run the `sourcegarph/server` Docker image: 
-
-```shell
-docker run --publish 7080:7080 --rm --network=lsp --name=sourcegraph --volume ~/.sourcegraph/config:/etc/sourcegraph --volume ~/.sourcegraph/data:/var/opt/sourcegraph -v /var/run/docker.sock:/var/run/docker.sock sourcegraph/server:2.7.6
-```
-
-2. Run the experimental HTML language server:
-
-  ```shell
-  docker pull sourcegraph/codeintel-html
-
-  docker run --rm --network=lsp --name=html sourcegraph/codeintel-html
-  ```
-
-3. Add the following entry to the `langservers` field in the [site configuration](https://about.sourcegraph.com/docs/config):
-
-  ```js
-  {
-      // ...
-      "langservers": [
-          // ...
-          {
-              "language": "html",
-              "address": "tcp://html:8080",
-              "metadata": {
-                "experimental": true,
-                "homepageURL": "https://github.com/Microsoft/vscode", 
-                "issuesURL": "https://github.com/Microsoft/vscode/issues", 
-                "docsURL": "https://github.com/Microsoft/vscode/blob/master/README.md"
-              }
-          },
-          // ...
-      ]
-      // ...
-  }
-  ```
+Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/preview-languages) for information on enabling this language server for your Sourcegraph installation.

--- a/dockerfiles/ocaml/README.md
+++ b/dockerfiles/ocaml/README.md
@@ -10,4 +10,4 @@ This Dockerfile adds experimental OCaml language support for Sourcegraph.
 
 Thanks to the [freebroccolo/ocaml-language-server](https://github.com/freebroccolo/ocaml-language-server) project for providing the language server that's wrapped by `lsp-adapter` in this image.
 
-Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/experimental-languages) for information on enabling this language server for your Sourcegraph installation.
+Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/experimental-language-servers) for information on enabling this language server for your Sourcegraph installation.

--- a/dockerfiles/ocaml/README.md
+++ b/dockerfiles/ocaml/README.md
@@ -10,4 +10,4 @@ This Dockerfile adds experimental OCaml language support for Sourcegraph.
 
 Thanks to the [freebroccolo/ocaml-language-server](https://github.com/freebroccolo/ocaml-language-server) project for providing the language server that's wrapped by `lsp-adapter` in this image.
 
-Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/preview-languages) for information on enabling this language server for your Sourcegraph installation.
+Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/experimental-languages) for information on enabling this language server for your Sourcegraph installation.

--- a/dockerfiles/ocaml/README.md
+++ b/dockerfiles/ocaml/README.md
@@ -10,43 +10,4 @@ This Dockerfile adds experimental OCaml language support for Sourcegraph.
 
 Thanks to the [freebroccolo/ocaml-language-server](https://github.com/freebroccolo/ocaml-language-server) project for providing the language server that's wrapped by `lsp-adapter` in this image.
 
-## How to add this language server to Sourcegraph
-
-*These steps are adapted from our documentation for [manually adding code intelligence to Sourcegraph server](https://about.sourcegraph.com/docs/code-intelligence/install-manual/).*
-
-1. Run the `sourcegarph/server` Docker image: 
-
-```shell
-docker run --publish 7080:7080 --rm --network=lsp --name=sourcegraph --volume ~/.sourcegraph/config:/etc/sourcegraph --volume ~/.sourcegraph/data:/var/opt/sourcegraph -v /var/run/docker.sock:/var/run/docker.sock sourcegraph/server:2.7.6
-```
-
-2. Run the experimental Dockerfile language server:
-
-  ```shell
-  docker pull sourcegraph/codeintel-ocaml
-
-  docker run --rm --network=lsp --name=ocaml sourcegraph/codeintel-ocaml
-  ```
-
-3. Add the following entry to the `langservers` field in the [site configuration](https://about.sourcegraph.com/docs/config):
-
-  ```js
-  {
-      // ...
-      "langservers": [
-          // ...
-          {
-              "language": "ocaml",
-              "address": "tcp://ocaml:8080",
-              "metadata": {
-                "experimental": true,
-                "homepageURL": "https://github.com/freebroccolo/ocaml-language-server", 
-                "issuesURL": "https://github.com/freebroccolo/ocaml-language-server/issues", 
-                "docsURL": "https://github.com/freebroccolo/ocaml-language-server/blob/master/README.md"
-              }
-          },
-          // ...
-      ]
-      // ...
-  }
-  ```
+Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/preview-languages) for information on enabling this language server for your Sourcegraph installation.

--- a/dockerfiles/ruby/README.md
+++ b/dockerfiles/ruby/README.md
@@ -10,4 +10,4 @@ This Dockerfile adds experimental Ruby language support for Sourcegraph.
 
 Thanks to the [castwide/solargraph](https://github.com/castwide/solargraph) project for providing the language server that's wrapped by `lsp-adapter` in this image.
 
-Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/experimental-languages) for information on enabling this language server for your Sourcegraph installation.
+Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/experimental-language-servers) for information on enabling this language server for your Sourcegraph installation.

--- a/dockerfiles/ruby/README.md
+++ b/dockerfiles/ruby/README.md
@@ -10,4 +10,4 @@ This Dockerfile adds experimental Ruby language support for Sourcegraph.
 
 Thanks to the [castwide/solargraph](https://github.com/castwide/solargraph) project for providing the language server that's wrapped by `lsp-adapter` in this image.
 
-Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/preview-languages) for information on enabling this language server for your Sourcegraph installation.
+Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/experimental-languages) for information on enabling this language server for your Sourcegraph installation.

--- a/dockerfiles/ruby/README.md
+++ b/dockerfiles/ruby/README.md
@@ -10,43 +10,4 @@ This Dockerfile adds experimental Ruby language support for Sourcegraph.
 
 Thanks to the [castwide/solargraph](https://github.com/castwide/solargraph) project for providing the language server that's wrapped by `lsp-adapter` in this image.
 
-## How to add this language server to Sourcegraph
-
-*These steps are adapted from our documentation for [manually adding code intelligence to Sourcegraph server](https://about.sourcegraph.com/docs/code-intelligence/install-manual/).*
-
-1. Run the `sourcegarph/server` Docker image: 
-
-```shell
-docker run --publish 7080:7080 --rm --network=lsp --name=sourcegraph --volume ~/.sourcegraph/config:/etc/sourcegraph --volume ~/.sourcegraph/data:/var/opt/sourcegraph -v /var/run/docker.sock:/var/run/docker.sock sourcegraph/server:2.7.6
-```
-
-2. Run the experimental Dockerfile language server:
-
-  ```shell
-  docker pull sourcegraph/codeintel-ruby
-
-  docker run --rm --network=lsp --name=ruby sourcegraph/codeintel-ruby
-  ```
-
-3. Add the following entry to the `langservers` field in the [site configuration](https://about.sourcegraph.com/docs/config):
-
-  ```js
-  {
-      // ...
-      "langservers": [
-          // ...
-          {
-              "language": "ruby",
-              "address": "tcp://ruby:8080",
-              "metadata": {
-                "experimental": true,
-                "homepageURL": "https://github.com/castwide/solargraph", 
-                "issuesURL": "https://github.com/castwide/solargraph/issues", 
-                "docsURL": "https://github.com/castwide/solargraph/blob/master/README.md"
-              }
-          },
-          // ...
-      ]
-      // ...
-  }
-  ```
+Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/preview-languages) for information on enabling this language server for your Sourcegraph installation.

--- a/dockerfiles/rust/README.md
+++ b/dockerfiles/rust/README.md
@@ -10,4 +10,4 @@ This Dockerfile adds experimental Rust language support for Sourcegraph.
 
 Thanks to the [rust-lang-nursery/rls](https://github.com/rust-lang-nursery/rls) project for providing the language server that's wrapped by `lsp-adapter` in this image.
 
-Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/preview-languages) for information on enabling this language server for your Sourcegraph installation.
+Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/experimental-languages) for information on enabling this language server for your Sourcegraph installation.

--- a/dockerfiles/rust/README.md
+++ b/dockerfiles/rust/README.md
@@ -10,4 +10,4 @@ This Dockerfile adds experimental Rust language support for Sourcegraph.
 
 Thanks to the [rust-lang-nursery/rls](https://github.com/rust-lang-nursery/rls) project for providing the language server that's wrapped by `lsp-adapter` in this image.
 
-Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/experimental-languages) for information on enabling this language server for your Sourcegraph installation.
+Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/experimental-language-servers) for information on enabling this language server for your Sourcegraph installation.

--- a/dockerfiles/rust/README.md
+++ b/dockerfiles/rust/README.md
@@ -10,43 +10,4 @@ This Dockerfile adds experimental Rust language support for Sourcegraph.
 
 Thanks to the [rust-lang-nursery/rls](https://github.com/rust-lang-nursery/rls) project for providing the language server that's wrapped by `lsp-adapter` in this image.
 
-## How to add this language server to Sourcegraph
-
-*These steps are adapted from our documentation for [manually adding code intelligence to Sourcegraph server](https://about.sourcegraph.com/docs/code-intelligence/install-manual/).*
-
-1. Run the `sourcegarph/server` Docker image: 
-
-```shell
-docker run --publish 7080:7080 --rm --network=lsp --name=sourcegraph --volume ~/.sourcegraph/config:/etc/sourcegraph --volume ~/.sourcegraph/data:/var/opt/sourcegraph -v /var/run/docker.sock:/var/run/docker.sock sourcegraph/server:2.7.6
-```
-
-2. Run the experimental Dockerfile language server:
-
-  ```shell
-  docker pull sourcegraph/codeintel-rust
-
-  docker run --rm --network=lsp --name=rust sourcegraph/codeintel-rust
-  ```
-
-3. Add the following entry to the `langservers` field in the [site configuration](https://about.sourcegraph.com/docs/config):
-
-  ```js
-  {
-      // ...
-      "langservers": [
-          // ...
-          {
-              "language": "rust",
-              "address": "tcp://rust:8080",
-              "metadata": {
-                "experimental": true,
-                "homepageURL": "https://github.com/rust-lang-nursery/rls", 
-                "issuesURL": "https://github.com/rust-lang-nursery/rls/issues", 
-                "docsURL": "https://github.com/rust-lang-nursery/rls/blob/master/README.md"
-              }
-          },
-          // ...
-      ]
-      // ...
-  }
-  ```
+Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/preview-languages) for information on enabling this language server for your Sourcegraph installation.


### PR DESCRIPTION
This removes all the manual installation instructions from each individual language's README and instead links to http://about.sourcegraph.com/docs/code-intelligence/preview-languages now that the manual steps are no longer necessary.

Fixes https://github.com/sourcegraph/lsp-adapter/issues/59
Fixes https://github.com/sourcegraph/sourcegraph/issues/11105 because the docs page will state the caveats