### PR TITLE
Add instructions for updating sourcegraph/codeintel-haskell

### DIFF
--- a/dockerfiles/haskell-ide-engine/README.md
+++ b/dockerfiles/haskell-ide-engine/README.md
@@ -1,0 +1,23 @@
+# How to update the sourcegraph/haskell-ide-engine image
+
+1. Open [./Dockerfile](./Dockerfile) and change the https://github.com/haskell/haskell-ide-engine commit:
+
+```diff
+   RUN git clone https://github.com/haskell/haskell-ide-engine --recursive /tmp/haskell-ide-engine \
+   && cd /tmp/haskell-ide-engine \
+-  && git checkout 562ac94d245e7b6ffa380eae4b02a832c397cfbb \
++  && git checkout 753deb91f9b9b39f14722315277d9fd587716bde \
+   # Avoid invalidating the layers when new commits are added.
+```
+
+2. Then build the image and tag it with the first 7 characters of the commit hash (e.g. 753deb9 - this is a convention):
+
+```
+docker build -t sourcegraph/haskell-ide-engine:<NEWTAG> -f dockerfiles/haskell-ide-engine/Dockerfile .
+```
+
+3. Push the image:
+
+```
+docker push sourcegraph/haskell-ide-engine:<NEWTAG>
+```

--- a/dockerfiles/haskell/Dockerfile
+++ b/dockerfiles/haskell/Dockerfile
@@ -7,7 +7,7 @@ RUN CGO_ENABLED=0 GOBIN=/usr/local/bin go install github.com/sourcegraph/lsp-ada
 # It has to be a separate, manually-built, image because the Travis environment
 # only provides 3 GB of RAM, which is not enough to compile haskell-ide-engine.
 # The Dockerfile is defined in ../haskell-ide-engine/Dockerfile.
-FROM sourcegraph/haskell-ide-engine:753deb9
+FROM sourcegraph/haskell-ide-engine:562ac94
 
 ENV TINI_VERSION v0.18.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini

--- a/dockerfiles/haskell/README.md
+++ b/dockerfiles/haskell/README.md
@@ -11,3 +11,16 @@ This Dockerfile adds experimental Haskell language support for Sourcegraph.
 Thanks to the [haskell/haskell-ide-engine](https://github.com/haskell/haskell-ide-engine) project for providing the language server that's wrapped by `lsp-adapter` in this image.
 
 Check out the [Sourcegraph docs](http://about.sourcegraph.com/docs/code-intelligence/experimental-language-servers) for information on enabling this language server for your Sourcegraph installation.
+
+## How to update the language server
+
+The [sourcegraph/codeintel-haskell](https://hub.docker.com/r/sourcegraph/codeintel-haskell) image follows a different build process from the other images because Travis is unable to compile [haskell-ide-engine](https://github.com/haskell/haskell-ide-engine) due to limited RAM.
+
+The way around this is to build an intermediate image [sourcegraph/haskell-ide-engine](https://hub.docker.com/r/sourcegraph/haskell-ide-engine) elsewhere (e.g. on your own machine), then have Travis use that as a base on which to build [sourcegraph/codeintel-haskell](https://hub.docker.com/r/sourcegraph/codeintel-haskell).
+
+In order to update the version of [haskell-ide-engine](https://github.com/haskell/haskell-ide-engine) in [sourcegraph/codeintel-haskell](https://hub.docker.com/r/sourcegraph/codeintel-haskell):
+
+1. Follow [../haskell-ide-engine/README.md](../haskell-ide-engine/README.md) to update [../haskell-ide-engine/Dockerfile](../haskell-ide-engine/Dockerfile) then build and push [sourcegraph/haskell-ide-engine](https://hub.docker.com/r/sourcegraph/haskell-ide-engine).
+1. In [./Dockerfile](./Dockerfile), replace the tag in the line `FROM sourcegraph/haskell-ide-engine:562ac94` with the tag you just created.
+1. Commit **both** of the Dockerfiles and submit a PR.
+1. After the PR is merged, Travis will automatically deploy [sourcegraph/codeintel-haskell](https://hub.docker.com/r/sourcegraph/codeintel-haskell).


### PR DESCRIPTION
Since Travis is unable to compile [haskell-ide-engine](https://github.com/haskell/haskell-ide-engine) due to limited RAM, a few manual steps are required to update the version of [haskell-ide-engine](https://github.com/haskell/haskell-ide-engine) in [sourcegraph/codeintel-haskell](https://hub.docker.com/r/sourcegraph/codeintel-haskell).