### PR TITLE
only dockerignore Dockerfiles and README.md in dockerfiles dir

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 .git/
-dockerfiles/
+dockerfiles/*/README.md
+dockerfiles/*/Dockerfile
 internal/
-
-!dockerfiles/ruby/solargraph-wrapper.go


### PR DESCRIPTION
This will allow us to use scripts/etc. defined in the `dockerfiles` folder when building an image. 