### PR TITLE
Resolve symlinks in the cacheDirectory

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -82,7 +82,7 @@ func main() {
 
 	// Ensure the path exists, otherwise symlinks to it cannot be resolved.
 	if err := os.MkdirAll(*unresolvedCacheDir, os.ModePerm); err != nil {
-		log.Fatal(err)
+		log.Fatalf("Error when checking -cacheDirectory=%q to check if it exists: %s", *unresolvedCacheDir, err)
 	}
 
 	// Resolve symlinks to avoid path mismatches in situations where the

--- a/proxy.go
+++ b/proxy.go
@@ -90,7 +90,7 @@ func main() {
 	// server: https://github.com/sourcegraph/sourcegraph/issues/11867
 	resolvedCacheDir, err := filepath.EvalSymlinks(*unresolvedCacheDir)
 	if err != nil {
-		log.Fatalf("Could not resolve symlinks in -cacheDirectory=%s because: %s", *unresolvedCacheDir, err)
+		log.Fatalf("Could not resolve symlinks in -cacheDirectory=%q because: %s", *unresolvedCacheDir, err)
 	}
 	cacheDir = &resolvedCacheDir
 

--- a/proxy.go
+++ b/proxy.go
@@ -25,13 +25,14 @@ import (
 )
 
 var (
-	proxyAddr         = flag.String("proxyAddress", "127.0.0.1:8080", "proxy server listen address (tcp)")
-	pprofAddr         = flag.String("pprofAddr", "", "server listen address for pprof")
-	cacheDir          = flag.String("cacheDirectory", filepath.Join(os.TempDir(), "proxy-cache"), "cache directory location")
-	didOpenLanguage   = flag.String("didOpenLanguage", "", "(HACK) If non-empty, send 'textDocument/didOpen' notifications with the specified language field (e.x. 'python') to the language server for every file.")
-	jsonrpc2IDRewrite = flag.String("jsonrpc2IDRewrite", "none", "(HACK) Rewrite jsonrpc2 ID. none (default) is no rewriting. string will use a string ID. number will use number ID. Useful for language servers with non-spec complaint JSONRPC2 implementations.")
-	glob              = flag.String("glob", "", "A colon (:) separated list of file globs to sync locally. By default we place all files into the workspace, but some language servers may only look at a subset of files. Specifying this allows us to avoid syncing all files. Note: This is done by basename only.")
-	trace             = flag.Bool("trace", true, "trace logs to stderr")
+	proxyAddr          = flag.String("proxyAddress", "127.0.0.1:8080", "proxy server listen address (tcp)")
+	pprofAddr          = flag.String("pprofAddr", "", "server listen address for pprof")
+	cacheDir           *string
+	unresolvedCacheDir = flag.String("cacheDirectory", filepath.Join(os.TempDir(), "proxy-cache"), "cache directory location")
+	didOpenLanguage    = flag.String("didOpenLanguage", "", "(HACK) If non-empty, send 'textDocument/didOpen' notifications with the specified language field (e.x. 'python') to the language server for every file.")
+	jsonrpc2IDRewrite  = flag.String("jsonrpc2IDRewrite", "none", "(HACK) Rewrite jsonrpc2 ID. none (default) is no rewriting. string will use a string ID. number will use number ID. Useful for language servers with non-spec complaint JSONRPC2 implementations.")
+	glob               = flag.String("glob", "", "A colon (:) separated list of file globs to sync locally. By default we place all files into the workspace, but some language servers may only look at a subset of files. Specifying this allows us to avoid syncing all files. Note: This is done by basename only.")
+	trace              = flag.Bool("trace", true, "trace logs to stderr")
 )
 
 type cloneProxy struct {
@@ -78,6 +79,20 @@ func main() {
 	default:
 		log.Fatalf("Invalid jsonrpc2IDRewrite value %q", *jsonrpc2IDRewrite)
 	}
+
+	// Ensure the path exists, otherwise symlinks to it cannot be resolved.
+	if err := os.MkdirAll(*unresolvedCacheDir, os.ModePerm); err != nil {
+		log.Fatal(err)
+	}
+
+	// Resolve symlinks to avoid path mismatches in situations where the
+	// language server resolves symlinks. One example is the Swift language
+	// server: https://github.com/sourcegraph/sourcegraph/issues/11867
+	resolvedCacheDir, err := filepath.EvalSymlinks(*unresolvedCacheDir)
+	if err != nil {
+		log.Fatalf("Could not resolve symlinks in -cacheDirectory=%s because: %s", *unresolvedCacheDir, err)
+	}
+	cacheDir = &resolvedCacheDir
 
 	lis, err := net.Listen("tcp", *proxyAddr)
 	if err != nil {


### PR DESCRIPTION
Unresolved symlinks were causing path mismatches with the Swift language server, specifically on macOS, where `/tmp` is sometimes symlinked to `/private/tmp`.

Fixes https://github.com/sourcegraph/sourcegraph/issues/11867