### PR TITLE
Switch from $HADOLINT to ~/hadolint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,10 @@ jobs:
     - stage: test
       env:
         # Path to 'hadolint' binary
-        HADOLINT: "${HOME}/hadolint"
+        - HADOLINT=$HOME/hadolint
       install:
         - go get -v golang.org/x/tools/cmd/goimports
-        - curl -sL -o ${HADOLINT} "https://github.com/hadolint/hadolint/releases/download/v1.6.5/hadolint-$(uname -s)-$(uname -m)" && chmod 700 ${HADOLINT}
+        - curl -sL -o $HADOLINT "https://github.com/hadolint/hadolint/releases/download/v1.6.5/hadolint-$(uname -s)-$(uname -m)" && chmod 700 ${HADOLINT}
       before_script:
         - cd $TRAVIS_BUILD_DIR
         - GO_FILES=$(find . -type f -name '*.go' -not -path "./vendor/*")

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,9 @@ jobs:
   include:
     # Test lsp-adapter and lint Dockerfiles
     - stage: test
-      env:
-        # Path to 'hadolint' binary
-        - HADOLINT=$HOME/hadolint
       install:
         - go get -v golang.org/x/tools/cmd/goimports
-        - curl -sL -o $HADOLINT "https://github.com/hadolint/hadolint/releases/download/v1.6.5/hadolint-$(uname -s)-$(uname -m)" && chmod 700 ${HADOLINT}
+        - curl -sL -o ~/hadolint "https://github.com/hadolint/hadolint/releases/download/v1.6.5/hadolint-$(uname -s)-$(uname -m)" && chmod 700 ~/hadolint
       before_script:
         - cd $TRAVIS_BUILD_DIR
         - GO_FILES=$(find . -type f -name '*.go' -not -path "./vendor/*")
@@ -30,7 +27,7 @@ jobs:
         - test -z $(goimports -d $GO_FILES) # this test asserts import ordering
         - test -z $(gofmt -s -d $GO_FILES)
         - go test -v ./...
-        - ${HADOLINT} dockerfiles/*/Dockerfile
+        - ~/hadolint dockerfiles/*/Dockerfile
     # Release lsp-adapter (only on tags)
     - stage: release
       if: tag =~ ^v AND fork = false


### PR DESCRIPTION
I'm not sure how this was working (maybe Travis has undocumented support for the key:value syntax)

https://docs.travis-ci.com/user/environment-variables/#Defining-public-variables-in-.travis.yml

```
env:
  - DB=postgres
  - SH=bash
  - PACKAGE_VERSION="1.0.*"
```