### PR TITLE
Unpin apt-get and apk package versions

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,5 @@
+ignored:
+  # Ignore unpinned apt-get package versions
+  - DL3008
+  # Ignore unpinned apk package versions
+  - DL3018

--- a/dockerfiles/bash/Dockerfile
+++ b/dockerfiles/bash/Dockerfile
@@ -6,20 +6,20 @@ RUN CGO_ENABLED=0 GOBIN=/usr/local/bin go install github.com/sourcegraph/lsp-ada
 FROM mongo:3.7.9
 
 RUN apt-get update \
-  && apt-get install --no-install-recommends -y curl=7.47.0-1ubuntu2.8 \
+  && apt-get install --no-install-recommends -y curl \
   && rm -rf /var/lib/apt/lists/*
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 RUN apt-get update \
   && apt-get install --no-install-recommends -y \
-    nodejs=8.11.3-1nodesource1 \
-    man-db=2.7.5-1 \
-    netcat=1.10-41 \
-    python=2.7.12-1~16.04 \
-    python-pip=8.1.1-2ubuntu0.4 \
-    git=1:2.7.4-0ubuntu1.4 \
-    yarn=1.7.0-1 \
+    nodejs \
+    man-db \
+    netcat \
+    python \
+    python-pip \
+    git \
+    yarn \
   && rm -rf /var/lib/apt/lists/*
 
 # Downgrade pip because explainshell depends on this API.
@@ -52,9 +52,9 @@ RUN chmod +x /tini
 ENTRYPOINT ["/tini", "--"]
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
-	make=4.1-6 \
-	gcc=4:5.3.1-1ubuntu1 \
-	g++=4:5.3.1-1ubuntu1 \
+	make \
+	gcc \
+	g++ \
   && rm -rf /var/lib/apt/lists/*
 
 # Ignore the warning about using WORKDIR instead of cd for convenience.

--- a/dockerfiles/clojure/Dockerfile
+++ b/dockerfiles/clojure/Dockerfile
@@ -4,7 +4,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOBIN=/usr/local/bin go install github.com/sourcegraph/lsp-adapter
 
 FROM clojure:lein-2.8.1-alpine
-RUN apk add --no-cache ca-certificates=20171114-r0 git=2.15.2-r0 tini=0.16.1-r0
+RUN apk add --no-cache ca-certificates git tini
 
 WORKDIR /tmp
 RUN git clone https://github.com/snoe/clojure-lsp.git

--- a/dockerfiles/csharp/Dockerfile
+++ b/dockerfiles/csharp/Dockerfile
@@ -8,7 +8,7 @@ RUN CGO_ENABLED=0 GOBIN=/usr/local/bin go install github.com/sourcegraph/lsp-ada
 FROM ubuntu:16.04
 
 RUN apt-get update \
-  && apt-get install --no-install-recommends -y ca-certificates=20170717~16.04.1 gnupg=1.4.20-1ubuntu3.1 curl=7.47.0-1ubuntu2.8 jq=1.5+dfsg-1 \
+  && apt-get install --no-install-recommends -y ca-certificates gnupg curl jq \
   # Ubuntu 16.04's default nodejs package v4.2.6 is too old to run the
   # omnisharp-client npm package.
   && curl -sL https://deb.nodesource.com/setup_10.x | bash - \
@@ -16,9 +16,9 @@ RUN apt-get update \
   && echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-xenial-prod xenial main" > /etc/apt/sources.list.d/dotnetdev.list \
   && echo "deb https://download.mono-project.com/repo/ubuntu stable-xenial main" > /etc/apt/sources.list.d/mono-official-stable.list \
   && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
-  && apt-get update && apt-get install --no-install-recommends -y apt-transport-https=1.2.26 \
+  && apt-get update && apt-get install --no-install-recommends -y apt-transport-https \
   # OmniSharp runs on Mono and requires the .NET SDK 2.0.0.
-  && apt-get update && apt-get install --no-install-recommends -y mono-complete=5.12.0.226-0xamarin3+ubuntu1604b1 dotnet-sdk-2.0.0=2.0.0-1 nodejs=10.4.1-1nodesource1 \
+  && apt-get update && apt-get install --no-install-recommends -y mono-complete dotnet-sdk-2.0.0 nodejs \
   # Removes ~1 GB of unused files.
   && rm -rf /usr/share/dotnet/sdk/NuGetFallbackFolder \
   && rm -rf /var/lib/apt/lists/* \

--- a/dockerfiles/docker/Dockerfile
+++ b/dockerfiles/docker/Dockerfile
@@ -5,7 +5,7 @@ RUN CGO_ENABLED=0 GOBIN=/usr/local/bin go install github.com/sourcegraph/lsp-ada
 
 FROM rcjsuen/docker-langserver:0.0.17
 
-RUN apk add --no-cache tini=0.16.1-r0
+RUN apk add --no-cache tini
 ENTRYPOINT ["tini", "--"]
 
 COPY --from=lsp-adapter /usr/local/bin/lsp-adapter /usr/local/bin/

--- a/dockerfiles/elixir/Dockerfile
+++ b/dockerfiles/elixir/Dockerfile
@@ -16,7 +16,7 @@ ENTRYPOINT ["/tini", "--"]
 
 ENV EXLIXIR_LS_VERSION v0.2.18
 ADD https://github.com/JakeBecker/elixir-ls/releases/download/${EXLIXIR_LS_VERSION}/elixir-ls.zip .
-RUN apt-get update && apt-get install --no-install-recommends -y unzip=6.0-21 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install --no-install-recommends -y unzip && rm -rf /var/lib/apt/lists/*
 RUN unzip elixir-ls.zip && rm elixir-ls.zip
 RUN chmod +x language_server.sh
 

--- a/dockerfiles/haskell-ide-engine/Dockerfile
+++ b/dockerfiles/haskell-ide-engine/Dockerfile
@@ -10,12 +10,12 @@ ARG STACK_VERSION=1.7.1
 # --no-install-recommends actually breaks tar.
 # hadolint ignore=DL3015
 RUN apt-get update && apt-get install -y \
-  git=1:2.7.4-0ubuntu1.3 \
-  wget=1.17.1-1ubuntu1.4 \
-  libtinfo-dev=6.0+20160213-1ubuntu1 \
-  build-essential=12.1ubuntu2 \
-  libgmp3-dev=2:6.1.0+dfsg-2 \
-  zlib1g-dev=1:1.2.8.dfsg-2ubuntu4.1 \
+  git \
+  wget \
+  libtinfo-dev \
+  build-essential \
+  libgmp3-dev \
+  zlib1g-dev \
   && rm -rf /var/lib/apt/lists/*
 
 RUN wget -qO- "https://github.com/commercialhaskell/stack/releases/download/v$STACK_VERSION/stack-$STACK_VERSION-linux-x86_64.tar.gz" | tar xz --wildcards --strip-components=1 -C /usr/local/bin '*/stack'

--- a/dockerfiles/lua/Dockerfile
+++ b/dockerfiles/lua/Dockerfile
@@ -8,7 +8,7 @@ RUN CGO_ENABLED=0 GOBIN=/usr/local/bin go install github.com/sourcegraph/lsp-ada
 
 FROM abaez/luarocks:lua5.1
 
-RUN apk add --no-cache ca-certificates=20161130-r2 git=2.13.7-r0 tini=0.14.0-r0
+RUN apk add --no-cache ca-certificates git tini
 
 ENTRYPOINT ["/sbin/tini", "--"]
 


### PR DESCRIPTION
Package distributors (e.g. Ubuntu) remove old versions of packages, which kept breaking our builds.

As a sanity check I built clojure, lua, docker, and elixir, and made sure that `docker run <name>` at least printed the `accepting connections` message from `lsp-adapter`.

Resolves https://github.com/sourcegraph/lsp-adapter/issues/72