### PR TITLE
Only build images on commits to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,14 @@ language: go
 go:
   - 1.10.x
 
-# Base configuration for the jobs that release the codeintel Docker images to DockerHub.
+# Base configuration for the jobs that release the codeintel Docker images to DockerHub (on commits to master).
 # Referenced further down.
 codeintel_image_release_job: &codeintel_image_release_job
   stage: release
   services:
     - docker
   install: skip
-  if: (branch = master OR branch =~ /^v.*$/) AND type = push AND fork = false
+  if: branch = master AND type = push AND fork = false
   script: bash deploy_image.sh
 
 jobs:


### PR DESCRIPTION
Closes #88 

- This fragment only affects the docker releases, not lsp-adapter binaries.
- Every tag has a commit, so for every tag we will have built the Docker images too.