### PR TITLE
Add cloneToCache flag

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -28,6 +28,7 @@ var (
 	proxyAddr          = flag.String("proxyAddress", "127.0.0.1:8080", "proxy server listen address (tcp)")
 	pprofAddr          = flag.String("pprofAddr", "", "server listen address for pprof")
 	cacheDir           *string
+	cloneToCache       = flag.Bool("cloneToCache", true, "use xfiles and xcontent to copy the workspace to the cacheDirectory")
 	unresolvedCacheDir = flag.String("cacheDirectory", filepath.Join(os.TempDir(), "proxy-cache"), "cache directory location")
 	didOpenLanguage    = flag.String("didOpenLanguage", "", "(HACK) If non-empty, send 'textDocument/didOpen' notifications with the specified language field (e.x. 'python') to the language server for every file.")
 	jsonrpc2IDRewrite  = flag.String("jsonrpc2IDRewrite", "none", "(HACK) Rewrite jsonrpc2 ID. none (default) is no rewriting. string will use a string ID. number will use number ID. Useful for language servers with non-spec complaint JSONRPC2 implementations.")
@@ -205,7 +206,7 @@ func (p *cloneProxy) handleServerRequest(ctx context.Context, conn *jsonrpc2.Con
 func (p *cloneProxy) handleClientRequest(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) {
 	<-p.ready
 
-	if req.Method == "initialize" {
+	if req.Method == "initialize" && *cloneToCache {
 		globs := strings.FieldsFunc(*glob, func(r rune) bool { return r == ':' })
 		if err := p.cloneWorkspaceToCache(globs); err != nil {
 			log.Println("CloneProxy.handleClientRequest(): cloning workspace failed during initialize", err)

--- a/uris.go
+++ b/uris.go
@@ -36,6 +36,10 @@ func (p *cloneProxy) workspaceCacheDir() string {
 }
 
 func clientToServerURI(uri lsp.DocumentURI, sysCacheDir string) lsp.DocumentURI {
+	if !*cloneToCache {
+		return uri
+	}
+
 	// sysCacheDir needs to be converted from a local path to a URI path
 	cacheDir := filepath.ToSlash(sysCacheDir)
 
@@ -57,6 +61,10 @@ func clientToServerURI(uri lsp.DocumentURI, sysCacheDir string) lsp.DocumentURI 
 }
 
 func serverToClientURI(uri lsp.DocumentURI, sysCacheDir string) lsp.DocumentURI {
+	if !*cloneToCache {
+		return uri
+	}
+
 	// sysCacheDir needs to be converted from a local path to a URI path
 	cacheDir := filepath.ToSlash(sysCacheDir)
 


### PR DESCRIPTION
This disables the use of `xfiles` and `xcontent` to copy the workspace to the `cacheDirectory` in order to enable VS Code to become a client.

VS Code [disallows the registration of request handlers](https://github.com/Microsoft/vscode-languageserver-node/blob/6d8ddcc7c2b4f65a7861438df88d46ed4b250fca/client/src/client.ts#L2360) (e.g. `xfiles`) before the `initialize` call has returned, while lsp-adapter sends `xfiles` and `xcontent` requests during `initialize` (which is technically invalid [LSP](https://microsoft.github.io/language-server-protocol/specification#initialize)) and expects responses. Therefore, these two are currently incompatible.

We have a few options:

- Fork https://github.com/Microsoft/vscode-languageserver-node to allow registration
- Defer cloning until after the `initialize` response is sent
- Work around this limitation by only connecting language servers that do not need more than the current file to provide code intelligence (this is what I'm doing now, and this is the motivation for this PR)