### PR TITLE
Remove use of ioutil package

### DIFF
--- a/dockerfiles/ruby/solargraph-wrapper.go
+++ b/dockerfiles/ruby/solargraph-wrapper.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/url"
 	"os"
@@ -138,7 +137,7 @@ func startSolargraph(ctx context.Context, dir string) (func() error, int, error)
 		if strings.HasPrefix(word, "PORT=") {
 			// We are done with scanning, but we need to keep reading stderr
 			// to prevent it blocking the process.
-			go io.Copy(ioutil.Discard, stderr)
+			go io.Copy(io.Discard, stderr)
 
 			port, err := strconv.Atoi(word[len("PORT="):])
 			if err != nil {

--- a/internal/cmd/lsp-record/lsp-record.go
+++ b/internal/cmd/lsp-record/lsp-record.go
@@ -11,7 +11,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -250,7 +249,7 @@ func newVFSHandler(ar *zip.ReadCloser) jsonrpc2HandlerFunc {
 						return nil, err
 					}
 					defer rc.Close()
-					b, err := ioutil.ReadAll(rc)
+					b, err := io.ReadAll(rc)
 					if err != nil {
 						return nil, err
 					}

--- a/proxy.go
+++ b/proxy.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/url"
@@ -253,7 +252,7 @@ func (p *cloneProxy) handleClientRequest(ctx context.Context, conn *jsonrpc2.Con
 					p.didOpenMu.Unlock()
 
 					if !sent {
-						b, err := ioutil.ReadFile(parsedURI.Path)
+						b, err := os.ReadFile(parsedURI.Path)
 						if err == nil {
 							err = p.server.Notify(ctx, "textDocument/didOpen", &lsp.DidOpenTextDocumentParams{
 								TextDocument: lsp.TextDocumentItem{

--- a/remote_fs.go
+++ b/remote_fs.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path"
@@ -150,7 +149,7 @@ func (fs *remoteFS) Clone(ctx context.Context, baseDir string, globs []string) (
 			return errors.Wrapf(err, "failed to make parent dirs for %s", newFilePath)
 		}
 
-		if err := ioutil.WriteFile(newFilePath, []byte(file.content), os.ModePerm); err != nil {
+		if err := os.WriteFile(newFilePath, []byte(file.content), os.ModePerm); err != nil {
 			return errors.Wrapf(err, "failed to write file content for %s", newFilePath)
 		}
 	}

--- a/remote_fs_test.go
+++ b/remote_fs_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/url"
 	"os"
@@ -80,7 +79,7 @@ func TestClone(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {
-			baseDir, err := ioutil.TempDir("", uuid.New().String()+"testClone")
+			baseDir, err := os.MkdirTemp("", uuid.New().String()+"testClone")
 			if err != nil {
 				t.Fatalf("when creating temp directory for clone test, err: %v", err)
 			}
@@ -118,7 +117,7 @@ func findAll(baseDir string) (map[string]string, error) {
 			return err
 		}
 
-		content, err := ioutil.ReadFile(currPath)
+		content, err := os.ReadFile(currPath)
 		if err != nil {
 			return err
 		}

--- a/uris_test.go
+++ b/uris_test.go
@@ -17,8 +17,8 @@ func TestProbablyFileURI(t *testing.T) {
 	tests := map[string]bool{
 		"file:///a.py":               true,
 		"file:///a.py#line=1,char=2": true,
-		"/a.py":    true,
-		"file:///": true,
+		"/a.py":                      true,
+		"file:///":                   true,
 
 		// We don't want to rewrite uris with an explicit non-file scheme
 		"git:///a.py": false,


### PR DESCRIPTION
Removes usage of the deprecated ioutil package as described [here](https://golang.org/doc/go1.16#ioutil)

[_Created by Sourcegraph batch change `rslade/deprecate-ioutil`._](https://k8s.sgdev.org/users/rslade/batch-changes/deprecate-ioutil)